### PR TITLE
core: Fix the check `variable is set`

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = function (variables) {
   var lostItems = []
 
   variables.forEach(function (variable) {
-    if (!env[variable]) {
+    if (!(variable in env)) {
       lostItems.push(variable)
     }
   })


### PR DESCRIPTION
An empty string `""` and `undefined` — are definitely different values, but both
are **falsey**. But the snippet you provided here can't differentiate them. So,
even if the variable **is set, but its value is an empty string** (it is legal) your
code will behave like the variable **is not set**. 

Now fixed.

from https://stackoverflow.com/a/52436493/1115187